### PR TITLE
Add null check to handleClickOutside

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ module.exports = function enhanceWithClickOutside(WrappedComponent) {
     },
 
     handleClickOutside(e) {
-      if (!React.findDOMNode(this).contains(e.target)) {
+      var domNode = React.findDOMNode(this);
+      if (!domNode || !domNode.contains(e.target)) {
         this.refs.wrappedComponent.handleClickOutside(e);
       }
     },

--- a/test/test.js
+++ b/test/test.js
@@ -101,4 +101,42 @@ describe('enhanceWithClickOutside', () => {
       'click', enhancedComponent.handleClickOutside, true
     )
   });
+
+  it('should always call the handleClickOutside if wrapped components render returns null', () => {
+    const clickOutsideSpy = expect.createSpy();
+
+    const WrappedComponent = React.createClass({
+      displayName: 'NullComponent',
+
+      handleClickOutside() {
+        clickOutsideSpy();
+      },
+
+      render() {
+        return null;
+      }
+    });
+    const EnhancedComponent = enhanceWithClickOutside(WrappedComponent);
+
+    const RootComponent = React.createClass({
+      render() {
+        return (
+            <div>
+              <EnhancedComponent ref="enhancedComponent" />
+            </div>
+        );
+      }
+    })
+
+    const rootComponent = React.render(<RootComponent />, document.body);
+
+    // We shouldn't TypeError when we try to call handleClickOutside
+    expect(() => {
+      rootComponent.refs.enhancedComponent.handleClickOutside();
+    }).toNotThrow(TypeError);
+
+    // If the component returns null, technically every click is an outside
+    // click, so we should call the inner handleClickOutside always
+    expect(clickOutsideSpy.calls.length).toBe(1);
+  });
 });


### PR DESCRIPTION
Currently when the inner component's `render()` function returns `null`, all clicks on the page will throw a `TypeError: Cannot read property 'contains' of null`.

I'm making it so that every click on the page will trigger the `handleClickOutside` of the inner component, since technically all clicks are "outside" of a DOM element that doesn't exist.