### PR TITLE
add mouseup event to trigger handleClickOutside

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,10 +10,12 @@ module.exports = function enhanceWithClickOutside(WrappedComponent) {
     componentDidMount() {
       this.__wrappedComponent = this.refs.wrappedComponent;
       document.addEventListener('click', this.handleClickOutside, true);
+      document.addEventListener('mousedown', this.handleClickOutside, true);
     },
 
     componentWillUnmount() {
       document.removeEventListener('click', this.handleClickOutside, true);
+      document.removeEventListener('mousedown', this.handleClickOutside, true);
     },
 
     handleClickOutside(e) {

--- a/index.js
+++ b/index.js
@@ -10,12 +10,12 @@ module.exports = function enhanceWithClickOutside(WrappedComponent) {
     componentDidMount() {
       this.__wrappedComponent = this.refs.wrappedComponent;
       document.addEventListener('click', this.handleClickOutside, true);
-      document.addEventListener('mousedown', this.handleClickOutside, true);
+      document.addEventListener('mouseup', this.handleClickOutside, true);
     },
 
     componentWillUnmount() {
       document.removeEventListener('click', this.handleClickOutside, true);
-      document.removeEventListener('mousedown', this.handleClickOutside, true);
+      document.removeEventListener('mouseup', this.handleClickOutside, true);
     },
 
     handleClickOutside(e) {


### PR DESCRIPTION
On chrome, there are times when you are doing a drag motion for handleClickOutside to not trigger, especially over another component that swallows events. This addition adds the `mouseup` event to account for dragging motion.
