### PR TITLE
Allow to provide `handleClickOutside` trough props

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -21,8 +21,10 @@ module.exports = function enhanceWithClickOutside(WrappedComponent) {
     },
     handleClickOutside: function handleClickOutside(e) {
       var domNode = ReactDOM.findDOMNode(this);
-      if ((!domNode || !domNode.contains(e.target)) && typeof this.refs.wrappedComponent.handleClickOutside === 'function') {
-        this.refs.wrappedComponent.handleClickOutside(e);
+      var handleClickOutside = this.refs.wrappedComponent.props.handleClickOutside || this.refs.wrappedComponent.handleClickOutside;
+
+      if ((!domNode || !domNode.contains(e.target)) && typeof handleClickOutside === 'function') {
+        handleClickOutside(e);
       }
     },
     render: function render() {

--- a/index.js
+++ b/index.js
@@ -19,9 +19,12 @@ module.exports = function enhanceWithClickOutside(WrappedComponent) {
 
     handleClickOutside(e) {
       const domNode = ReactDOM.findDOMNode(this);
+      const handleClickOutside = this.refs.wrappedComponent.props.handleClickOutside ||
+        this.refs.wrappedComponent.handleClickOutside;
+
       if ((!domNode || !domNode.contains(e.target)) &&
-        typeof this.refs.wrappedComponent.handleClickOutside === 'function') {
-        this.refs.wrappedComponent.handleClickOutside(e);
+        typeof handleClickOutside === 'function') {
+        handleClickOutside(e);
       }
     },
 

--- a/index.js
+++ b/index.js
@@ -19,8 +19,9 @@ module.exports = function enhanceWithClickOutside(WrappedComponent) {
 
     handleClickOutside(e) {
       const domNode = ReactDOM.findDOMNode(this);
-      const handleClickOutside = this.refs.wrappedComponent.props.handleClickOutside ||
-        this.refs.wrappedComponent.handleClickOutside;
+      const component = this.refs.wrappedComponent;
+      const handleClickOutside = component.props.handleClickOutside ||
+        component.handleClickOutside;
 
       if ((!domNode || !domNode.contains(e.target)) &&
         typeof handleClickOutside === 'function') {

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,39 @@ function simulateClick(node) {
   return event;
 }
 
+const TestComponent = React.createClass({
+  handleClick() {
+    this.props.clickInsideSpy();
+  },
+
+  handleClickOutside(e) {
+    this.testBoundToComponent(e);
+  },
+
+  testBoundToComponent(e) {
+    this.props.clickOutsideSpy(e);
+  },
+
+  render() {
+    return (
+      <div onClick={this.handleClick}>
+        <div ref="nested" />
+      </div>
+    );
+  },
+});
+
+const WrapComponent = (Component) => React.createClass({
+  render() {
+    return (
+      <div>
+        <Component ref="inside" {...this.props} />
+        <div ref="outside" />
+      </div>
+    )
+  },
+});
+
 const mountNode = document.createElement('div');
 document.body.appendChild(mountNode);
 
@@ -22,51 +55,22 @@ describe('enhanceWithClickOutside', () => {
     const clickInsideSpy = expect.createSpy();
     const clickOutsideSpy = expect.createSpy();
 
-    const ToBeEnhancedComponent = React.createClass({
-      handleClick() {
-        clickInsideSpy();
-      },
+    const EnhancedComponent = enhanceWithClickOutside(TestComponent);
+    const Root = WrapComponent(EnhancedComponent);
 
-      handleClickOutside(e) {
-        this.testBoundToComponent(e);
-      },
+    const rootComponent = ReactDOM.render(<Root 
+      clickInsideSpy={clickInsideSpy}
+      clickOutsideSpy={clickOutsideSpy}
+    />, mountNode);
 
-      testBoundToComponent(e) {
-        clickOutsideSpy(e);
-      },
-
-      render() {
-        return (
-          <div onClick={this.handleClick}>
-            <div ref="nested" />
-          </div>
-        );
-      },
-    });
-
-    const EnhancedComponent = enhanceWithClickOutside(ToBeEnhancedComponent);
-
-    const Root = React.createClass({
-      render() {
-        return (
-          <div>
-            <EnhancedComponent ref="enhancedComponent"/>
-            <div ref="outsideComponent" />
-          </div>
-        );
-      },
-    });
-
-    const rootComponent = ReactDOM.render(<Root />, mountNode);
-
-    const enhancedComponent = rootComponent.refs.enhancedComponent;
+    const enhancedComponent = rootComponent.refs.inside;
     const enhancedNode = ReactDOM.findDOMNode(enhancedComponent);
 
     const wrappedComponent = enhancedComponent.__wrappedComponent;
 
     const nestedNode = ReactDOM.findDOMNode(wrappedComponent.refs.nested);
 
-    const outsideNode = rootComponent.refs.outsideComponent;
+    const outsideNode = rootComponent.refs.outside;
 
     simulateClick(enhancedNode);
     expect(clickInsideSpy.calls.length).toBe(1);
@@ -82,6 +86,52 @@ describe('enhanceWithClickOutside', () => {
 
     const event = simulateClick(outsideNode);
     expect(clickOutsideSpy).toHaveBeenCalledWith(event);
+
+    expect.spyOn(document, 'removeEventListener').andCallThrough();
+    ReactDOM.unmountComponentAtNode(mountNode);
+    expect(document.removeEventListener).toHaveBeenCalledWith(
+      'click', enhancedComponent.handleClickOutside, true
+    );
+  });
+
+  it('calls handleClickOutside from props if provided', () => {
+    const clickInsideSpy = expect.createSpy();
+    const clickOutSideViaPropSpy = expect.createSpy();
+    const clickOutsideSpy = expect.createSpy();
+
+    const EnhancedComponent = enhanceWithClickOutside(TestComponent);
+    const Root = WrapComponent(EnhancedComponent);
+
+    const rootComponent = ReactDOM.render(<Root 
+      clickInsideSpy={clickInsideSpy}
+      clickOutsideSpy={clickOutsideSpy}
+      handleClickOutside={clickOutSideViaPropSpy}
+    />, mountNode);
+
+    const enhancedComponent = rootComponent.refs.inside;
+    const enhancedNode = ReactDOM.findDOMNode(enhancedComponent);
+
+    const wrappedComponent = enhancedComponent.__wrappedComponent;
+    const nestedNode = ReactDOM.findDOMNode(wrappedComponent.refs.nested);
+    const outsideNode = rootComponent.refs.outside;
+
+    simulateClick(enhancedNode);
+    expect(clickInsideSpy.calls.length).toBe(1);
+    expect(clickOutsideSpy.calls.length).toBe(0);
+    expect(clickOutSideViaPropSpy.calls.length).toBe(0);
+
+    simulateClick(nestedNode);
+    expect(clickInsideSpy.calls.length).toBe(2);
+    expect(clickOutsideSpy.calls.length).toBe(0);
+    expect(clickOutSideViaPropSpy.calls.length).toBe(0);
+
+    // Stop propagation in the outside node should not prevent the
+    // handleOutsideClick handler from being called
+    outsideNode.addEventListener('click', e => e.stopPropagation());
+
+    const event = simulateClick(outsideNode);
+    expect(clickOutsideSpy.calls.length).toBe(0);
+    expect(clickOutSideViaPropSpy).toHaveBeenCalledWith(event);
 
     expect.spyOn(document, 'removeEventListener').andCallThrough();
     ReactDOM.unmountComponentAtNode(mountNode);

--- a/test/test.js
+++ b/test/test.js
@@ -39,7 +39,7 @@ const WrapComponent = (Component) => React.createClass({
         <Component ref="inside" {...this.props} />
         <div ref="outside" />
       </div>
-    )
+    );
   },
 });
 
@@ -58,10 +58,13 @@ describe('enhanceWithClickOutside', () => {
     const EnhancedComponent = enhanceWithClickOutside(TestComponent);
     const Root = WrapComponent(EnhancedComponent);
 
-    const rootComponent = ReactDOM.render(<Root 
-      clickInsideSpy={clickInsideSpy}
-      clickOutsideSpy={clickOutsideSpy}
-    />, mountNode);
+    const rootComponent = ReactDOM.render(
+      <Root
+        clickInsideSpy={clickInsideSpy}
+        clickOutsideSpy={clickOutsideSpy}
+      />,
+      mountNode
+    );
 
     const enhancedComponent = rootComponent.refs.inside;
     const enhancedNode = ReactDOM.findDOMNode(enhancedComponent);
@@ -102,11 +105,14 @@ describe('enhanceWithClickOutside', () => {
     const EnhancedComponent = enhanceWithClickOutside(TestComponent);
     const Root = WrapComponent(EnhancedComponent);
 
-    const rootComponent = ReactDOM.render(<Root 
-      clickInsideSpy={clickInsideSpy}
-      clickOutsideSpy={clickOutsideSpy}
-      handleClickOutside={clickOutSideViaPropSpy}
-    />, mountNode);
+    const rootComponent = ReactDOM.render(
+      <Root
+        clickInsideSpy={clickInsideSpy}
+        clickOutsideSpy={clickOutsideSpy}
+        handleClickOutside={clickOutSideViaPropSpy}
+      />,
+      mountNode
+    );
 
     const enhancedComponent = rootComponent.refs.inside;
     const enhancedNode = ReactDOM.findDOMNode(enhancedComponent);


### PR DESCRIPTION
This PR makes it possible that the handler is provided trough the `props`.

Why? Because I don't want to bind for example the `Redux` state directly to a component. Now I can use a `container` that wraps the `component` and provides a `clickHandler` to change a specific key in the `redux state`.

Modified sample from [redux.js.org][1]
```js
// components/todolist.js
const TodoList = ({ todos, handleClick }) => (
  <ul>
    {todos.map(todo =>
      <Todo key={todo.id} {...todo} onClick={() => handleClick(todo.id)} />
    )}
  </ul>
);

export default TodoList;
```

```js
// containers/todolist.js
import { connect } from 'react-redux'
import Component from '../components/todolist';
import handleClickOutside from 'react-click-outside';

const mapStateToProps = (state) => state;

const mapDispatchToProps = (dispatch) => ({
  handleClick: (id) => {
    dispatch({ type: 'TOGGLE_TODO', payload: id });
  },

  handleClickOutside: (id) => {
    dispatch({ type: 'CLOSE_TODOLIST' });
  },
});

const TodoList = connect(
  mapStateToProps,
  mapDispatchToProps
)(Component)

export default handleClickOutside(TodoList);
```

[1]: http://redux.js.org/docs/basics/UsageWithReact.html

* edit 2016-11-09: move `handleClickOutside` wrapper to container.