### PR TITLE
Guard against unmounted components

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -45,8 +45,8 @@ module.exports = function enhanceWithClickOutside(WrappedComponent) {
       key: 'handleClickOutside',
       value: function handleClickOutside(e) {
         var domNode = this.__domNode;
-        if ((!domNode || !domNode.contains(e.target)) && typeof this.__wrappedComponent.handleClickOutside === 'function') {
-          this.__wrappedComponent.handleClickOutside(e);
+        if ((!domNode || !domNode.contains(e.target)) && this.__wrappedInstance && typeof this.__wrappedInstance.handleClickOutside === 'function') {
+          this.__wrappedInstance.handleClickOutside(e);
         }
       }
     }, {
@@ -60,7 +60,7 @@ module.exports = function enhanceWithClickOutside(WrappedComponent) {
 
         return React.createElement(WrappedComponent, _extends({}, rest, {
           ref: function ref(c) {
-            _this2.__wrappedComponent = c;
+            _this2.__wrappedInstance = c;
             _this2.__domNode = ReactDOM.findDOMNode(c);
             wrappedRef && wrappedRef(c);
           }

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ module.exports = function enhanceWithClickOutside(WrappedComponent) {
       const domNode = this.__domNode;
       if (
         (!domNode || !domNode.contains(e.target)) &&
+        this.__wrappedInstance &&
         typeof this.__wrappedInstance.handleClickOutside === 'function'
       ) {
         this.__wrappedInstance.handleClickOutside(e);

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,5 @@
+global.requestAnimationFrame = callback => setTimeout(callback, 0);
+
 const Adapter = require('enzyme-adapter-react-16');
 const { configure } = require('enzyme');
 


### PR DESCRIPTION
Hi!
We were getting some errors at https://www.timebillingapp.com/ trying to execute `handleClickOutside` on `undefined`. This patch has been on our production app for some time and it corrected the issue.

As a bonus, this fixes a react warning that showed on jest. 