### PR TITLE
Allow passing callback though the props

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -25,9 +25,39 @@ const Target = (() => {
   return enhanceWithClickOutside(Target);
 })();
 
+const WrappedTarget = (() => {
+  class WrappedTarget extends React.Component {
+    render() {
+      return <div style={style}>{this.props.children}</div>;
+    }
+  }
+
+  return enhanceWithClickOutside(WrappedTarget);
+})();
+
+class TargetWithPassedProps extends React.Component {
+  constructor() {
+    super();
+    this.state = { text: 'waiting for click outside' };
+  }
+
+  handleClickOutside() {
+    this.setState({ text: new Date().toString() });
+  }
+
+  render() {
+    return (
+      <WrappedTarget handleClickOutside={this.handleClickOutside.bind(this)}>
+        {this.state.text}
+      </WrappedTarget>
+    );
+  }
+}
+
 const Root = () => (
   <div>
     <Target />
+    <TargetWithPassedProps />
     <button style={style}>Button Element</button>
   </div>
 );

--- a/dist/index.js
+++ b/dist/index.js
@@ -45,8 +45,12 @@ function enhanceWithClickOutside(Component) {
       key: 'handleClickOutside',
       value: function handleClickOutside(e) {
         var domNode = this.__domNode;
-        if ((!domNode || !domNode.contains(e.target)) && this.__wrappedInstance && typeof this.__wrappedInstance.handleClickOutside === 'function') {
-          this.__wrappedInstance.handleClickOutside(e);
+        if ((!domNode || !domNode.contains(e.target)) && this.__wrappedInstance) {
+          if (typeof this.__wrappedInstance.handleClickOutside === 'function') {
+            this.__wrappedInstance.handleClickOutside(e);
+          } else if (typeof this.__wrappedInstance.props.handleClickOutside === 'function') {
+            this.__wrappedInstance.props.handleClickOutside(e);
+          }
         }
       }
     }, {

--- a/index.js
+++ b/index.js
@@ -27,12 +27,14 @@ function enhanceWithClickOutside(Component: React.ComponentType<*>) {
 
     handleClickOutside(e) {
       const domNode = this.__domNode;
-      if (
-        (!domNode || !domNode.contains(e.target)) &&
-        this.__wrappedInstance &&
-        typeof this.__wrappedInstance.handleClickOutside === 'function'
-      ) {
-        this.__wrappedInstance.handleClickOutside(e);
+      if ((!domNode || !domNode.contains(e.target)) && this.__wrappedInstance) {
+        if (typeof this.__wrappedInstance.handleClickOutside === 'function') {
+          this.__wrappedInstance.handleClickOutside(e);
+        } else if (
+          typeof this.__wrappedInstance.props.handleClickOutside === 'function'
+        ) {
+          this.__wrappedInstance.props.handleClickOutside(e);
+        }
       }
     }
 


### PR DESCRIPTION
Allow passing prop `handleClickOutside` to the enhanced component. Not only declaring method inside the component itself.