### PR TITLE
added preact compatibility. used with preact-compat

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -45,7 +45,7 @@ function enhanceWithClickOutside(Component) {
       key: 'handleClickOutside',
       value: function handleClickOutside(e) {
         var domNode = this.__domNode;
-        if ((!domNode || !domNode.contains(e.target)) && this.__wrappedInstance && typeof this.__wrappedInstance.handleClickOutside === 'function') {
+        if ((!domNode || (domNode.contains ? !domNode.contains(e.target) : !domNode.base.contains(e.target))) && this.__wrappedInstance && typeof this.__wrappedInstance.handleClickOutside === 'function') {
           this.__wrappedInstance.handleClickOutside(e);
         }
       }

--- a/index.js
+++ b/index.js
@@ -28,7 +28,10 @@ function enhanceWithClickOutside(Component: React.ComponentType<*>) {
     handleClickOutside(e) {
       const domNode = this.__domNode;
       if (
-        (!domNode || !domNode.contains(e.target)) &&
+        (!domNode ||
+          (domNode.contains
+            ? !domNode.contains(e.target)
+            : !domNode.base.contains(e.target))) &&
         this.__wrappedInstance &&
         typeof this.__wrappedInstance.handleClickOutside === 'function'
       ) {


### PR DESCRIPTION
In Preact (a lighter alternative to React), domNode returns an object that contains the HTML Element and does not provide a method within Component that supports contains.

Therefore, contains is undefined in Preact.

This has been tested.