### PR TITLE
Allow hoist-non-react-statics 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "react-test-renderer": "16.0.0"
   },
   "dependencies": {
-    "hoist-non-react-statics": "^2.1.1"
+    "hoist-non-react-statics": ">=2.1.1 <4.0.0"
   }
 }


### PR DESCRIPTION
Version 3.x only dropped support for React 0.14. Since this library can also work with more recent versions, this is compatible.

yarn.lock probably needs updating but I don't know how. IMHO a library should never include lock files in the git repo anyway.